### PR TITLE
Add handling of structured seed descriptor in etcd

### DIFF
--- a/src/main/java/org/zalando/cassandra/locator/SeedDescriptor.java
+++ b/src/main/java/org/zalando/cassandra/locator/SeedDescriptor.java
@@ -1,0 +1,22 @@
+package org.zalando.cassandra.locator;
+
+public class SeedDescriptor {
+    private String host;
+    private String availabilityZone;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(final String host) {
+        this.host = host;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(final String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+}


### PR DESCRIPTION
The expected structure for now is either host-or-ip or a JSON object of this
format:

{
    "host": <host-or-ip>,
    "availabilityZone": <zone-name>
}